### PR TITLE
Fix msg.voice processing to handle neural voices correctly and bump to v0.0.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-polly-tts",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/polly-tts/polly-tts.html
+++ b/polly-tts/polly-tts.html
@@ -130,6 +130,7 @@
             <option value='69'>Takumi (ja-JP)</option>
             <option value='70'>Zeina (arb)</option>
             <option value='71'>Zhiyu (cmn-CN)</option>
+	    <option value='72'>Olivia - neural (en-AU)</option>
         </select>
     </div>
     <div class="form-row">
@@ -161,7 +162,7 @@
     </p>
 
     <p>
-        The voice can be specified by setting <code>msg.voice</code> to e.g. <i>Joanna</i> or <i>Enrique</i>.
+	The voice can be specified by setting <code>msg.voice</code> to e.g. <i>Joanna</i> or <i>Enrique</i>.  For neural voices use the name followed by '(neural)', e.g. <i>Ivy (neural)</i> or <i>Matthew (neural)</i>
     </p>
 
     <p>

--- a/polly-tts/polly-tts.js
+++ b/polly-tts/polly-tts.js
@@ -500,7 +500,7 @@ module.exports = function(RED) {
             LanguageCode: 'en-US',
             LanguageName: 'US English',
             Name: 'Salli (neural)',
-            Engine: 'neural'
+	    Engine: 'neural'
 		},
         '57': {
             Gender: 'Male',
@@ -621,6 +621,14 @@ module.exports = function(RED) {
             LanguageName: 'Chinese, Mandarin',
             Name: 'Zhiyu',
             Engine: 'standard'
+		},
+	'72': {
+	    Gender: 'Female',
+	    Id: 'Olivia',
+	    LanguageCode: 'en-AU',
+	    LanguageName: 'Australian English',
+	    Name: 'Olivia (neural)',
+	    Engine: 'neural'
 		}
     };
 
@@ -663,6 +671,7 @@ module.exports = function(RED) {
 
         // Set the voice
         var defaultVoice = voices[config.voice].Id;
+	var engine = voices[config.voice].Engine
 
         // Set ssml
         this.ssml = config.ssml;
@@ -685,12 +694,12 @@ module.exports = function(RED) {
             };
             var voice = defaultVoice
 
-            if(Object.values(voices).map(obj => {return obj.Id}).includes(msg.voice)) {
-                voice = msg.voice
-            }
-
-            var engine = voices[config.voice].Engine
-
+	    var voiceIndex = Object.values(voices).findIndex(obj => {return obj.Name === msg.voice})
+	    if(voiceIndex > -1) {
+		voice = voices[voiceIndex].Id
+		engine = voices[voiceIndex].Engine
+	    }
+	    
             var polly = node.config.polly;
             var outputFormat = 'mp3';
 


### PR DESCRIPTION
The original change I put in to add neural voices did not deal correctly with `msg.voice` being passed.

This pull request corrects that error and adds some information to the help text explaining how to specify the neural voices.

I've also added another Neural voice (Olivia) and bumped the version to 0.0.15.

Kind regards,

Brett